### PR TITLE
Corrected syntax error at Series 1, Card 31

### DIFF
--- a/blockchains/counterparty/rare-coco/rare-coco.json
+++ b/blockchains/counterparty/rare-coco/rare-coco.json
@@ -482,8 +482,11 @@
                         {
                             "name": "NIIIX",
                             "link": "https://x.com/niiix_____"
-                        },
-                        {
+                            }
+                    ],
+                    "subAssets": []
+                },
+                  {
                             "edition": "32",
                             "name": "BITCOCO",
                             "images": {
@@ -3216,6 +3219,4 @@
                     ]
                 }
             ]
-        }
-    ]
-}
+        }  


### PR DESCRIPTION
Was missing subasset after artist name which broke the rest of the set.